### PR TITLE
Fix exports and main

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "plugin",
     "split"
   ],
-  "exports": "./index.js",
+  "main": "dist/index.js",
+  "exports": "./dist/index.js",
   "type": "module",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
the following message was occured when test rehype-split-paragraph jest.

> Cannot find module 'rehype-split-paragraph' from 'src/lib/html.ts'

https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c#gistcomment-37194
